### PR TITLE
ci(stack): auto-update Stack section in PR bodies

### DIFF
--- a/.github/workflows/stack-pr-body.yml
+++ b/.github/workflows/stack-pr-body.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update PR body with Stack section
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const owner = context.repo.owner;


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: develop
- Próxima: (topo)
- Cadeia: #62
<!-- stack-section:end -->

Adiciona workflow que mantém a seção 'Stack' no topo do body das PRs:
- Atualiza Parent/Next automaticamente com base na relação base→head entre PRs abertas
- Usa marcadores <!-- stack-section:begin/end --> para idempotência
- Dispara em opened/edited/synchronize/reopened

Complementa o Mermaid em docs/stack-plan/STACK-PR-PLAN.md
