### PR TITLE
ci(stack-graph): não commitar em branches gh/* (evita conflitos em ghstack)

### DIFF
--- a/.github/workflows/stack-graph.yml
+++ b/.github/workflows/stack-graph.yml
@@ -88,8 +88,11 @@ jobs:
             core.setOutput('changed', String(newContent !== content));
 
       - name: Commit changes (if any)
-        # Do not attempt to push to protected main; still run on other branches
-        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+        # Do not attempt to push to protected main, and skip ghstack synthetic branches
+        if: >-
+          ${ { github.event_name == 'push' &&
+                github.ref != 'refs/heads/main' &&
+                !startsWith(github.ref, 'refs/heads/gh/') } }
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: gh/revton/4/base
- Próxima: (topo)
- Cadeia: #107
<!-- stack-section:end -->

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #107
* #106
* #105
* #104
