### PR TITLE
docs(issues): template de Issue alinhado ao Project v2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).
 - `docs/project/PHASE_PLAN.md` — plano por fases, releases e governança de branch.
 - `docs/project/ISSUES.csv` — backlog estruturado usado como referência para criação/priorização de Issues.
+ - `docs/templates/ISSUE_TEMPLATE.md` — modelo de issue alinhado aos campos do Project v2 (tipo, prioridade, módulo, OpenAPI?, ADR?).
 
 ## Ferramentas e Scripts
 - Scripts PowerShell de automação ficam em `scripts/` (ex.: utilitários com GitHub CLI `gh`).
@@ -34,4 +35,3 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - Sempre usar PRs contra `main` e preferir "Squash and merge".
 - Fechamento automático de Issues: incluir `Closes #<id>` nas PRs que entram em `main`.
 - Manter os arquivos de documentação acima atualizados quando houver mudanças de processo, fluxo de stack ou organização de Project.
-

--- a/docs/templates/ISSUE_TEMPLATE.md
+++ b/docs/templates/ISSUE_TEMPLATE.md
@@ -1,0 +1,51 @@
+# Template de Issue — Car Fuel
+
+Use este modelo ao abrir novas issues no repositório. Ele foi pensado para ficar alinhado aos campos do Project v2 descritos em `docs/PROJECTS.md` e ao processo em `docs/PROCESSO.md`.
+
+## Contexto
+- **Resumo curto:**
+- **Problema / oportunidade:**
+- **Motivação (por que agora?):**
+
+## Escopo
+- **Incluído:**
+- **Fora de escopo:**
+
+## Critérios de aceite
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Impacto
+- **Tipo (feat/fix/docs/ci/chore):**
+- **Módulo (repo/docs/ci/api/domain/webapp/etc):**
+- **Afeta contrato OpenAPI? (Sim/Não):**
+- **Requer ADR? (Sim/Não):**
+- **Dependências conhecidas (Issues/PRs/serviços):**
+
+## Riscos e mitigação
+- **Riscos principais:**
+- **Mitigações previstas:**
+
+## Plano de validação
+- **Testes manuais/automatizados esperados:**
+- **Critérios para considerar "Done":**
+
+## Campos do Project (GitHub Projects v2)
+> Preencha estes campos ao adicionar/atualizar o card no Project, conforme `docs/PROJECTS.md`.
+
+- **Status:** Backlog / In Progress / Review / Done
+- **Priority:** P1 (crítico) / P2 (importante) / P3 (melhoria)
+- **Type:** feat / fix / docs / ci / chore
+- **Area:** repo / docs / ci / api / domain / webapp / outro
+- **OpenAPI?:** Sim / Não
+- **ADR?:** Sim / Não
+
+## Checklist
+- [ ] Preenchi o contexto e o escopo da issue
+- [ ] Defini critérios de aceite claros e verificáveis
+- [ ] Avaliei impacto em módulos, contratos OpenAPI e ADRs
+- [ ] Registrei riscos principais e possíveis mitigações
+- [ ] Defini como a issue será validada/testada
+- [ ] Atualizei os campos do Project v2 (Status, Priority, Type, Area, OpenAPI?, ADR?)
+


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #115
<!-- stack-section:end -->

Adiciona um template de Issues em  e referencia no índice .

- Campos alinhados ao Project v2: Status, Priority, Type, Area, OpenAPI?, ADR? (conforme )
- Inclui seções de Contexto, Escopo, Critérios de aceite, Impacto, Riscos/Mitigações e Plano de validação
- Checklist final reforça preenchimento de campos do Project e critérios de aceite

Não adiciona nem altera workflows de Actions; apenas documentação.

Closes #6
