### PR TITLE
docs(api-style): criar API_STYLE.md e integrar às diretrizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/project/PHASE_PLAN.md`: estado macro das fases. Atualize sempre que uma fase fechar ou iniciar.
 - `.github/pull_request_template.md`: checklist exigido; mantenha a estrutura nos PRs.
 - `.github/workflows/ghstack-land.yml`: workflow manual para `ghstack land`. Exige o secret `GHSTACK_TOKEN` com escopo `repo`.
+- `docs/API_STYLE.md`: convenções de API HTTP (versionamento, recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters). Use sempre que houver rotas/contratos de API.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/API_STYLE.md
+++ b/docs/API_STYLE.md
@@ -1,0 +1,55 @@
+# Guia de Estilo de API — Car Fuel
+
+Este documento define convenções para APIs HTTP deste repositório, complementando `docs/DIRETRIZES.md` (Padrões de API) e orientando futuros contratos (OpenAPI, gateways, serviços).
+
+## Versionamento
+- Usar versionamento explícito no caminho (ex.: `/v1/...`).
+- Evitar breaking changes dentro da mesma versão; para mudanças incompatíveis, criar `/v2/`.
+- Quando necessário, suportar versões antigas por um período definido e documentar depreciações.
+
+## Recursos e URLs
+- Usar substantivos no plural: `/vehicles`, `/fills`, `/users`.
+- IDs simples no caminho: `/vehicles/{vehicleId}`.
+- Sub-recursos quando fizer sentido: `/vehicles/{vehicleId}/fills`.
+- Filtros por query string: `/fills?vehicleId={id}&from={data}&to={data}`.
+
+## Métodos e semântica
+- `GET` — leitura (idempotente, sem efeitos colaterais).
+- `POST` — criação de recurso ou ação não idempotente.
+- `PUT` — substituição total de recurso existente.
+- `PATCH` — atualização parcial.
+- `DELETE` — remoção lógica ou física (documentar qual).
+
+## Códigos de status
+- 2xx: `200 OK`, `201 Created`, `204 No Content`.
+- 4xx: `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, `409 Conflict`, `422 Unprocessable Entity`.
+- 5xx: `500 Internal Server Error` (erros inesperados); preferir log detalhado e resposta enxuta.
+
+## Paginação
+- Padrão sugerido: `page` e `per_page` ou paginação por cursor.
+- Resposta deve incluir metadados de paginação (páginas/total ou próximo cursor).
+
+## Headers
+- `Content-Type`: `application/json; charset=utf-8`.
+- `Accept`: preferir `application/json`.
+- Header de correlação (ex.: `X-Request-Id`) para rastrear requisições ponta a ponta.
+
+## Segurança
+- Sempre sob HTTPS; nunca enviar credenciais em HTTP.
+- Autenticação a definir (token/JWT/OAuth) — documentar no contrato da API.
+- Evitar vazamento de informações sensíveis em mensagens de erro.
+
+## Depreciação
+- Marcar endpoints em depreciação na documentação.
+- Se possível, adicionar header de aviso (ex.: `Deprecation` / `Link` para doc).
+- Definir janela de suporte (data ou versão) e segui-la.
+
+## Convenções de payload
+- JSON com campos em `camelCase` ou `snake_case` (escolher e manter consistente).
+- Datas em ISO 8601 (`YYYY-MM-DDTHH:mm:ssZ`).
+- Erros com estrutura consistente (código interno, mensagem, detalhes e `requestId`).
+
+## Linters e validação
+- Ao introduzir OpenAPI/Swagger, usar linters (como `spectral`) no CI para validar contratos.
+- Contratos devem ser versionados junto com o código e revisados via PR.
+

--- a/docs/DIRETRIZES.md
+++ b/docs/DIRETRIZES.md
@@ -8,9 +8,10 @@ Este documento define diretrizes para desenvolvimento, qualidade e fluxo de entr
 - Observabilidade como requisito: logs estruturados, métricas e rastreabilidade em operações críticas.
 
 ## Padrões de API (quando houver backend)
-- REST pragmático, versionamento no caminho (ex.: `/v1/...`) ou via header.
+- REST pragmático, versionamento no caminho (ex.: `/v1/...`).
 - Respostas consistentes de erro (código, mensagem, detalhes), com correlação de requisições.
 - Idempotência em operações sensíveis; validações e mensagens claras.
+- Detalhamento adicional em `docs/API_STYLE.md` (recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
 
 ## Qualidade de Código
 - Mensagens de commit em Conventional Commits (ex.: `feat:`, `fix:`, `docs:`, `ci:`, `chore:`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 ## Índice de Documentação
 - `AGENTS.md` — contexto para agentes/automação (Codex Cloud, ghstack-land, checks obrigatórios).
 - `docs/DIRETRIZES.md` — diretrizes de desenvolvimento (arquitetura, qualidade, CI/CD, fluxo de PRs).
+- `docs/API_STYLE.md` — guia de estilo de API (versionamento, recursos, métodos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #116
<!-- stack-section:end -->

Cria o guia  e integra com as demais documentações, atendendo à Issue #7.

- Define convenções de API HTTP: versionamento, recursos/URLs, métodos, códigos de status, paginação, headers, segurança, depreciação, convenções de payload e linters de OpenAPI
- Atualiza  para apontar para o API_STYLE como detalhamento dos Padrões de API
- Atualiza  para incluir o API_STYLE no índice de documentação
- Atualiza  para lembrar agentes/Codex de seguir  quando houver rotas/contratos de API

Closes #7
