### PR TITLE
docs(errors): criar catálogo de erros (ERRORS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `.github/pull_request_template.md`: checklist exigido; mantenha a estrutura nos PRs.
 - `.github/workflows/ghstack-land.yml`: workflow manual para `ghstack land`. Exige o secret `GHSTACK_TOKEN` com escopo `repo`.
 - `docs/API_STYLE.md`: convenções de API HTTP (versionamento, recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters). Use sempre que houver rotas/contratos de API.
+ - `docs/ERRORS.md`: catálogo de erros para APIs (envelope padrão, `code` internos, exemplos e diretrizes para OpenAPI). Ao definir endpoints, alinhar os erros a este catálogo.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/API_STYLE.md
+++ b/docs/API_STYLE.md
@@ -24,6 +24,7 @@ Este documento define convenções para APIs HTTP deste repositório, complement
 - 2xx: `200 OK`, `201 Created`, `204 No Content`.
 - 4xx: `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, `409 Conflict`, `422 Unprocessable Entity`.
 - 5xx: `500 Internal Server Error` (erros inesperados); preferir log detalhado e resposta enxuta.
+- Ver mapeamentos e códigos internos em `docs/ERRORS.md`.
 
 ## Paginação
 - Padrão sugerido: `page` e `per_page` ou paginação por cursor.
@@ -47,9 +48,8 @@ Este documento define convenções para APIs HTTP deste repositório, complement
 ## Convenções de payload
 - JSON com campos em `camelCase` ou `snake_case` (escolher e manter consistente).
 - Datas em ISO 8601 (`YYYY-MM-DDTHH:mm:ssZ`).
-- Erros com estrutura consistente (código interno, mensagem, detalhes e `requestId`).
+- Erros com estrutura consistente conforme `docs/ERRORS.md` (envelope tipo RFC 7807 com `code`, `status`, `title`, `detail`, `requestId`).
 
 ## Linters e validação
 - Ao introduzir OpenAPI/Swagger, usar linters (como `spectral`) no CI para validar contratos.
 - Contratos devem ser versionados junto com o código e revisados via PR.
-

--- a/docs/DIRETRIZES.md
+++ b/docs/DIRETRIZES.md
@@ -11,7 +11,7 @@ Este documento define diretrizes para desenvolvimento, qualidade e fluxo de entr
 - REST pragmático, versionamento no caminho (ex.: `/v1/...`).
 - Respostas consistentes de erro (código, mensagem, detalhes), com correlação de requisições.
 - Idempotência em operações sensíveis; validações e mensagens claras.
-- Detalhamento adicional em `docs/API_STYLE.md` (recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
+- Detalhamento adicional em `docs/API_STYLE.md` (recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters) e `docs/ERRORS.md` (envelope de erro, códigos internos e exemplos).
 
 ## Qualidade de Código
 - Mensagens de commit em Conventional Commits (ex.: `feat:`, `fix:`, `docs:`, `ci:`, `chore:`).

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -1,0 +1,75 @@
+# Catálogo de Erros — Car Fuel
+
+Este documento define o formato padrão de erros para APIs HTTP do projeto, alinhado ao estilo descrito em `docs/API_STYLE.md`.
+
+## Envelope de erro (inspirado na RFC 7807)
+
+Erro de API deve ser retornado em JSON com os campos abaixo (compatível com `application/problem+json`):
+
+- `type` (string, opcional): URI ou identificador da categoria de erro (ex.: `"https://car-fuel/errors/vehicle_not_found"`).
+- `title` (string, obrigatório): resumo curto, estável e legível (ex.: `"Vehicle not found"`).
+- `status` (number, obrigatório): código HTTP correspondente (ex.: `404`).
+- `detail` (string, opcional): mensagem detalhada, específica da ocorrência.
+- `instance` (string, opcional): URI ou identificador da ocorrência (ex.: caminho da rota).
+- `code` (string, obrigatório): código interno estável (ex.: `"vehicle_not_found"`).
+- `requestId` (string, opcional): id de correlação da requisição (mesmo valor de `X-Request-Id`).
+- `errors` (object, opcional): mapa de erros de validação por campo (ex.: `{ "plate": ["invalid_format"] }`).
+
+### Exemplo de payload de erro
+
+```json
+{
+  "type": "https://car-fuel/errors/vehicle_not_found",
+  "title": "Vehicle not found",
+  "status": 404,
+  "detail": "No vehicle was found for id '123'",
+  "instance": "/v1/vehicles/123",
+  "code": "vehicle_not_found",
+  "requestId": "f4c0f291-1c3e-4d1e-9f7c-123456789abc"
+}
+```
+
+## Códigos comuns e mapeamentos
+
+Sugestão de códigos internos (campo `code`) e mapeamento para HTTP:
+
+| code                       | HTTP status | Descrição                                   |
+|----------------------------|------------|---------------------------------------------|
+| `vehicle_not_found`        | 404        | Veículo não encontrado                      |
+| `fill_not_found`           | 404        | Abastecimento não encontrado                |
+| `invalid_fill_payload`     | 400        | Dados de abastecimento inválidos            |
+| `invalid_query_params`     | 400        | Parâmetros de consulta inválidos            |
+| `unauthorized`             | 401        | Não autenticado                             |
+| `forbidden`                | 403        | Sem permissão para acessar o recurso        |
+| `conflict`                 | 409        | Conflito de estado (ex.: recurso duplicado) |
+| `rate_limited`             | 429        | Limite de requisições excedido              |
+| `internal_error`           | 500        | Erro interno inesperado                     |
+
+Ao adicionar novos erros de domínio, crie códigos internos consistentes (snake_case) e documente-os neste catálogo.
+
+## Erros de validação
+
+Para erros de validação de payload ou query string, use `status = 400` ou `422` e preencha o campo `errors`:
+
+```json
+{
+  "title": "Invalid request",
+  "status": 400,
+  "code": "invalid_fill_payload",
+  "errors": {
+    "odometer": ["must_be_positive"],
+    "liters": ["must_be_greater_than_zero"]
+  }
+}
+```
+
+## OpenAPI / Padrões de contrato
+
+Ao modelar erros em OpenAPI/Swagger:
+
+- Definir um schema compartilhado para o envelope de erro (ex.: `ProblemDetails`).
+- Reutilizar esse schema em respostas padrão (ex.: `400Error`, `404Error`, `DefaultError`).
+- Quando possível, referenciar `code` e `type` com enum ou documentação textual.
+
+O objetivo é manter erros previsíveis para clientes (tanto humanos quanto automações) e garantir que qualquer mudança de formato seja centralmente controlada por este catálogo.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `AGENTS.md` — contexto para agentes/automação (Codex Cloud, ghstack-land, checks obrigatórios).
 - `docs/DIRETRIZES.md` — diretrizes de desenvolvimento (arquitetura, qualidade, CI/CD, fluxo de PRs).
 - `docs/API_STYLE.md` — guia de estilo de API (versionamento, recursos, métodos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
+ - `docs/ERRORS.md` — catálogo de erros (envelope tipo RFC 7807, campos, códigos internos e exemplos para OpenAPI).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #117
<!-- stack-section:end -->

Cria o catálogo de erros em  e integra com os guias existentes, atendendo à Issue #8.

- Define envelope de erro inspirado na RFC 7807 (, , , , , , , )
- Lista códigos internos comuns e mapeamento para HTTP (ex.: , , , )
- Inclui exemplos de payload de erro e de validação ( por campo)
- Atualiza  para referenciar o catálogo ao falar de códigos de status e payload de erro
- Atualiza  e  para apontar para 
- Atualiza  para lembrar agentes/Codex de seguir o catálogo ao definir endpoints/contratos

Closes #8
