### PR TITLE
docs(nfr): adicionar NFR.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `.github/pull_request_template.md`: checklist exigido; mantenha a estrutura nos PRs.
 - `.github/workflows/ghstack-land.yml`: workflow manual para `ghstack land`. Exige o secret `GHSTACK_TOKEN` com escopo `repo`.
 - `docs/API_STYLE.md`: convenções de API HTTP (versionamento, recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters). Use sempre que houver rotas/contratos de API.
- - `docs/ERRORS.md`: catálogo de erros para APIs (envelope padrão, `code` internos, exemplos e diretrizes para OpenAPI). Ao definir endpoints, alinhar os erros a este catálogo.
+- `docs/ERRORS.md`: catálogo de erros para APIs (envelope padrão, `code` internos, exemplos e diretrizes para OpenAPI). Ao definir endpoints, alinhar os erros a este catálogo.
+- `docs/NFR.md`: NFRs (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo). Ao propor soluções de arquitetura, verifique alinhamento com estes requisitos.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/DIRETRIZES.md
+++ b/docs/DIRETRIZES.md
@@ -6,6 +6,7 @@ Este documento define diretrizes para desenvolvimento, qualidade e fluxo de entr
 - Separação por camadas: borda (APIs/CLI/Jobs), domínio (regras), infraestrutura (persistência/integr.)
 - APIs contract‑first quando aplicável; documentação e contratos versionados com o código.
 - Observabilidade como requisito: logs estruturados, métricas e rastreabilidade em operações críticas.
+- NFRs (performance, resiliência, escalabilidade, etc.) sumarizados em `docs/NFR.md`.
 
 ## Padrões de API (quando houver backend)
 - REST pragmático, versionamento no caminho (ex.: `/v1/...`).

--- a/docs/NFR.md
+++ b/docs/NFR.md
@@ -1,0 +1,48 @@
+# Requisitos Não Funcionais (NFRs) — Car Fuel
+
+Este documento registra requisitos não funcionais esperados para o sistema Car Fuel. Ele serve como referência de decisões e trade-offs durante o desenho de APIs, serviços e integrações.
+
+## SLOs (Service Level Objectives)
+- Disponibilidade alvo: **99,5%** para funcionalidades centrais (registro e consulta de abastecimentos).
+- Latência alvo (p95):
+  - Leitura simples (ex.: GET /fills/{id}): **≤ 300 ms**.
+  - Listagens com filtros simples: **≤ 500 ms**.
+- Erro 5xx (pico): idealmente < **1%** das requisições em períodos normais.
+
+Estes valores são referências de projeto, não SLAs contratuais.
+
+## Performance
+- Evitar N+1 em consultas; preferir agregações apropriadas e uso parcimonioso de JOINs.
+- Paginação obrigatória em listagens potencialmente grandes.
+- Operações de escrita devem ser otimizadas para o caminho comum (ex.: registro de abastecimento) e não exigir validações excessivamente caras.
+
+## Resiliência
+- Timeouts razoáveis em chamadas externas (para evitar requisições presas indefinidamente).
+- Re-tentativas idempotentes em operações de leitura ou comandos seguros (cuando fizer sentido), com backoff.
+- Foco em falha segura: se um componente opcional falhar (ex.: envio de notificação), a operação principal não deve necessariamente ser abortada.
+
+## Escalabilidade
+- Arquitetura preparada para escalar horizontalmente onde fizer sentido (stateless em camadas de borda).
+- Uso de cache para leituras quentes quando necessário, com estratégias claras de invalidação.
+- Limites por requisição (page size, payload máximo) para evitar uso abusivo.
+
+## Segurança e Observabilidade (resumo)
+- Todas as comunicações externas devem usar HTTPS.
+- Logs estruturados com correlação por `requestId`.
+- Métricas de latência, taxa de erro e volume por endpoint devem ser passíveis de coleta.
+- Erros devem seguir o catálogo de `docs/ERRORS.md`.
+
+## Dados
+- Consistência: eventual onde aceitável, forte em operações críticas (ex.: registro de abastecimento e saldos derivados imediatos).
+- Retenção: datas de abastecimento e dados históricos devem ser mantidos por período suficiente para análise de consumo; regras detalhadas podem ser documentadas em ADRs específicos.
+- Privacidade: dados de localização ou identificadores pessoais devem ser tratados com cuidado, minimizando armazenamento quando não essencial.
+
+## Operabilidade
+- Deve ser possível identificar rapidamente a causa de falhas frequentes via logs e métricas.
+- Releases devem ser incrementais e reversíveis (rollback simples).
+- Feature flags podem ser usadas para ativar/desativar funcionalidades sem novo deploy.
+
+## Custo
+- Escolhas de arquitetura devem considerar simplicidade e custo operacional (infraestrutura, storage, observabilidade).
+- Evitar dependências complexas quando um design mais simples atende aos requisitos funcionais e não funcionais.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `AGENTS.md` — contexto para agentes/automação (Codex Cloud, ghstack-land, checks obrigatórios).
 - `docs/DIRETRIZES.md` — diretrizes de desenvolvimento (arquitetura, qualidade, CI/CD, fluxo de PRs).
 - `docs/API_STYLE.md` — guia de estilo de API (versionamento, recursos, métodos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
- - `docs/ERRORS.md` — catálogo de erros (envelope tipo RFC 7807, campos, códigos internos e exemplos para OpenAPI).
+- `docs/ERRORS.md` — catálogo de erros (envelope tipo RFC 7807, campos, códigos internos e exemplos para OpenAPI).
+ - `docs/NFR.md` — requisitos não funcionais (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #118
<!-- stack-section:end -->

Cria o documento  com requisitos não funcionais e integra com as diretrizes existentes, atendendo à Issue #9.

- Documenta SLOs de disponibilidade/latência, expectativas de performance e resiliência
- Registra diretrizes de escalabilidade, segurança/observabilidade (em alto nível), dados, operabilidade e custo
- Atualiza  para apontar para  na seção de arquitetura
- Atualiza  e  para incluir o NFR no índice e no contexto de agentes

Closes #9
