### PR TITLE
docs(env): criar ENVIRONMENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/API_STYLE.md`: convenções de API HTTP (versionamento, recursos, códigos, paginação, headers, segurança, depreciação, convenções e linters). Use sempre que houver rotas/contratos de API.
 - `docs/ERRORS.md`: catálogo de erros para APIs (envelope padrão, `code` internos, exemplos e diretrizes para OpenAPI). Ao definir endpoints, alinhar os erros a este catálogo.
 - `docs/NFR.md`: NFRs (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo). Ao propor soluções de arquitetura, verifique alinhamento com estes requisitos.
+ - `docs/ENVIRONMENTS.md`: visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção. Considere sempre o ambiente alvo ao automatizar scripts e pipelines.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -1,0 +1,46 @@
+# Ambientes — Car Fuel
+
+Este documento descreve os ambientes previstos para o Car Fuel e como pensar variáveis/segredos, CORS, flags, observabilidade, limites, dados e promoção entre eles.
+
+## Ambientes previstos
+- **Local**: desenvolvimento na máquina do dev (ex.: API em localhost, banco local/contêiner). Maior liberdade de logs e dados de teste.
+- **Dev / Preview** (futuro): ambiente compartilhado para validação rápida de features; pode usar dados sintéticos.
+- **Prod** (futuro): ambiente real de uso, com dados de usuários; políticas de segurança, observabilidade e limites mais rígidas.
+
+## Variáveis e segredos
+- Em desenvolvimento local, usar arquivos `.env` (não versionados) ou variáveis de ambiente.
+- Em pipelines/Actions, usar GitHub Secrets para tokens/chaves sensíveis.
+- Nunca commitar chaves, tokens ou credenciais (API keys, senhas, connection strings) no repositório.
+- Parametrizar URLs de backend, chaves de API e credenciais via env vars específicas por ambiente.
+
+## CORS
+- Local/dev: permitir origens de desenvolvimento conhecidas (ex.: `http://localhost:*`).
+- Prod: restringir a origens oficiais (domínios da aplicação) e apenas métodos/headers necessários.
+- Evitar wildcards amplos (`*`) em produção para origens e headers sensíveis.
+
+## Feature flags
+- Funcionalidades experimentais devem ser controladas via flags (env vars ou config) por ambiente.
+- Em local/dev, flags podem ser ligadas por padrão; em prod, devem ser ativadas explicitamente.
+- Flags devem ter nomes claros e, quando removidas, limpar também o código morto associado.
+
+## Observabilidade por ambiente
+- Local/dev: nível de log mais verboso; logs podem incluir mais detalhes (sem dados sensíveis).
+- Prod: logs estruturados com foco em correlação (`requestId`) e diagnóstico; evitar dados pessoais nos logs.
+- Métricas e traces devem permitir identificar problemas por ambiente (tag `env=local/dev/prod`).
+
+## Limites e uso
+- Aplicar limites de tamanho de payload e page size em endpoints que listam recursos.
+- Para futuros serviços públicos, considerar rate limiting por chave/usuário/IP, com políticas diferentes por ambiente.
+
+## Dados
+- Local/dev: preferir dados sintéticos; se usar dumps de produção, anonimizar dados sensíveis.
+- Prod: seguir as regras de retenção e privacidade do projeto (ver NFRs e ADRs relevantes).
+
+## Promoção entre ambientes
+- Fluxo sugerido (quando existirem dev/prod):
+  1. Commit/PR → merge em `main`.
+  2. Deploy automático ou manual em dev/preview.
+  3. Validação (testes, smoke, métricas).
+  4. Promoção para prod (deploy a partir da mesma artefato/commit).
+- Mudanças de configuração sensíveis devem ser revisadas em PRs específicas e testadas em dev antes de ir para prod.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/DIRETRIZES.md` — diretrizes de desenvolvimento (arquitetura, qualidade, CI/CD, fluxo de PRs).
 - `docs/API_STYLE.md` — guia de estilo de API (versionamento, recursos, métodos, códigos, paginação, headers, segurança, depreciação, convenções e linters).
 - `docs/ERRORS.md` — catálogo de erros (envelope tipo RFC 7807, campos, códigos internos e exemplos para OpenAPI).
- - `docs/NFR.md` — requisitos não funcionais (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo).
+- `docs/NFR.md` — requisitos não funcionais (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo).
+ - `docs/ENVIRONMENTS.md` — visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção.
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #119
<!-- stack-section:end -->

Cria o documento  e integra com o índice e AGENTS, atendendo à Issue #10.

- Descreve ambientes previstos (local, dev/preview, prod) e o papel de cada um
- Documenta diretrizes para variáveis/segredos, CORS, feature flags e observabilidade por ambiente
- Registra orientações sobre limites, dados (dados sintéticos/anonimização) e fluxo de promoção entre ambientes
- Atualiza  para incluir ENVIRONMENTS no índice de documentação
- Atualiza  para lembrar agentes/Codex de consultar ENVIRONMENTS ao lidar com scripts, pipelines e configurações por ambiente

Closes #10
