### PR TITLE
docs(privacy): criar PRIVACY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/ERRORS.md`: catálogo de erros para APIs (envelope padrão, `code` internos, exemplos e diretrizes para OpenAPI). Ao definir endpoints, alinhar os erros a este catálogo.
 - `docs/NFR.md`: NFRs (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo). Ao propor soluções de arquitetura, verifique alinhamento com estes requisitos.
 - `docs/ENVIRONMENTS.md`: visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção. Considere sempre o ambiente alvo ao automatizar scripts e pipelines.
- - `docs/SECURITY.md`: baseline de segurança (authZ/authN, transporte, CORS, rate limiting, segredos/cripto, supply chain, CI/CD, auditoria, incidentes). Consulte antes de sugerir alterações que afetem segurança.
+- `docs/SECURITY.md`: baseline de segurança (authZ/authN, transporte, CORS, rate limiting, segredos/cripto, supply chain, CI/CD, auditoria, incidentes). Consulte antes de sugerir alterações que afetem segurança.
+ - `docs/PRIVACY.md`: baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes). Use ao propor logs, telemetria ou novas fontes de dados de usuário.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -34,7 +34,7 @@ Este documento descreve os ambientes previstos para o Car Fuel e como pensar var
 
 ## Dados
 - Local/dev: preferir dados sintéticos; se usar dumps de produção, anonimizar dados sensíveis.
-- Prod: seguir as regras de retenção e privacidade do projeto (ver NFRs e ADRs relevantes).
+- Prod: seguir as regras de retenção e privacidade do projeto (ver `docs/NFR.md`, `docs/PRIVACY.md` e ADRs relevantes).
 
 ## Promoção entre ambientes
 - Fluxo sugerido (quando existirem dev/prod):
@@ -43,4 +43,3 @@ Este documento descreve os ambientes previstos para o Car Fuel e como pensar var
   3. Validação (testes, smoke, métricas).
   4. Promoção para prod (deploy a partir da mesma artefato/commit).
 - Mudanças de configuração sensíveis devem ser revisadas em PRs específicas e testadas em dev antes de ir para prod.
-

--- a/docs/NFR.md
+++ b/docs/NFR.md
@@ -35,7 +35,7 @@ Estes valores são referências de projeto, não SLAs contratuais.
 ## Dados
 - Consistência: eventual onde aceitável, forte em operações críticas (ex.: registro de abastecimento e saldos derivados imediatos).
 - Retenção: datas de abastecimento e dados históricos devem ser mantidos por período suficiente para análise de consumo; regras detalhadas podem ser documentadas em ADRs específicos.
-- Privacidade: dados de localização ou identificadores pessoais devem ser tratados com cuidado, minimizando armazenamento quando não essencial.
+- Privacidade: dados de localização ou identificadores pessoais devem ser tratados com cuidado, minimizando armazenamento quando não essencial. Ver detalhes em `docs/PRIVACY.md`.
 
 ## Operabilidade
 - Deve ser possível identificar rapidamente a causa de falhas frequentes via logs e métricas.
@@ -45,4 +45,3 @@ Estes valores são referências de projeto, não SLAs contratuais.
 ## Custo
 - Escolhas de arquitetura devem considerar simplicidade e custo operacional (infraestrutura, storage, observabilidade).
 - Evitar dependências complexas quando um design mais simples atende aos requisitos funcionais e não funcionais.
-

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,49 @@
+# Privacidade — Car Fuel
+
+Este documento registra princípios de privacidade para o Car Fuel. Não é uma política jurídica formal, mas um baseline técnico para orientar decisões de dados e código.
+
+## Classificação de dados
+- **Dados de veículo**: modelo, ano, placa, identificação interna.
+- **Dados de consumo**: quilometragem, litros, valores de abastecimento.
+- **Dados de usuário** (se existirem): identificadores de conta, e-mail, nome, preferências.
+- **Dados técnicos**: logs de requisições, métricas, IDs de sessão.
+
+Em geral, dados de usuário e placa podem ser considerados dados pessoais/identificáveis; logs e métricas devem evitar armazenar esses valores em claro sempre que possível.
+
+## Minimização de dados
+- Coletar apenas os dados necessários para as funcionalidades do Car Fuel.
+- Em logs, evitar registrar PII diretamente (ex.: placa completa, e-mail). Se necessário, mascarar ou usar identificadores internos.
+- Em ambientes de dev/test, preferir dados sintéticos ou dumps anonimizados (ver `docs/ENVIRONMENTS.md`).
+
+## Base legal (visão de alto nível)
+- Qualquer uso real com dados pessoais deve estar ancorado em base legal adequada (ex.: consentimento, legítimo interesse, obrigação legal).
+- Ao projetar novas funcionalidades que envolvam dados pessoais, considerar se a base legal está clara e documentar em ADRs quando apropriado.
+
+## Retenção
+- Dados de consumo (abastecimentos e métricas) devem ser mantidos apenas pelo tempo necessário para análise de eficiência e histórico para o usuário.
+- Logs de aplicação e access logs devem ter janelas de retenção razoáveis (ex.: 30–90 dias), conforme necessidade de diagnóstico.
+- Dumps usados em dev/test devem ser rotacionados e descartados quando não forem mais necessários.
+
+## Direitos do usuário (alto nível)
+- O sistema deve facilitar, no futuro, funcionalidades como:
+  - Acesso aos dados próprios (exportar histórico de consumo).
+  - Correção de dados incorretos.
+  - Exclusão de dados de conta, quando aplicável.
+- Mesmo antes dessas funcionalidades existirem, o desenho de dados deve facilitar implementá-las sem grandes retrabalhos.
+
+## Subprocessadores
+- Serviços de terceiros (ex.: armazenamento em nuvem, analytics) que venham a processar dados devem ser considerados subprocessadores.
+- Ao introduzir um novo serviço externo, avaliar que tipos de dados ele receberá e se isso está alinhado aos princípios deste documento.
+
+## Telemetria
+- Telemetria deve focar em métricas agregadas (ex.: número de requisições, latências, taxas de erro).
+- Evitar incluir dados pessoais em eventos de telemetria; quando inevitável, considerar anonimização ou pseudonimização.
+- Qualquer integração com ferramentas de analytics deve ser revisada à luz deste documento e de `docs/SECURITY.md`.
+
+## Incidentes de privacidade
+- Em caso de incidente envolvendo dados pessoais (ex.: exposição indevida de logs), deve-se:
+  - Identificar rapidamente a extensão (quais dados, por quanto tempo).
+  - Corrigir a causa raiz (ajuste de log, permissão, código, configuração).
+  - Rotacionar segredos ou credenciais afetadas.
+  - Registrar o incidente em canal apropriado (issue privada ou doc interno) para aprendizado futuro.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/ERRORS.md` — catálogo de erros (envelope tipo RFC 7807, campos, códigos internos e exemplos para OpenAPI).
 - `docs/NFR.md` — requisitos não funcionais (SLOs, performance, resiliência, escalabilidade, segurança/observabilidade, dados, operabilidade, custo).
 - `docs/ENVIRONMENTS.md` — visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção.
- - `docs/SECURITY.md` — diretrizes gerais de segurança (authN/authZ, transporte, CORS, rate limiting, segredos, supply chain, CI/CD, incidentes).
+- `docs/SECURITY.md` — diretrizes gerais de segurança (authN/authZ, transporte, CORS, rate limiting, segredos, supply chain, CI/CD, incidentes).
+ - `docs/PRIVACY.md` — baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #121
<!-- stack-section:end -->

Cria o documento  com baseline de privacidade e integra com as demais docs, atendendo à Issue #12.

- Define classificação de dados (veículo, consumo, usuário, técnicos) e recomenda evitar PII em logs
- Estabelece princípios de minimização de dados e uso de dados sintéticos/anonimizados em dev/test
- Aborda base legal em alto nível, retenção de dados, direitos do usuário e subprocessadores
- Documenta diretrizes para telemetria focada em métricas agregadas e tratamento de incidentes de privacidade
- Atualiza , ,  e  para referenciar PRIVACY

Closes #12
