### PR TITLE
docs(observability): criar OBSERVABILITY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/ENVIRONMENTS.md`: visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção. Considere sempre o ambiente alvo ao automatizar scripts e pipelines.
 - `docs/SECURITY.md`: baseline de segurança (authZ/authN, transporte, CORS, rate limiting, segredos/cripto, supply chain, CI/CD, auditoria, incidentes). Consulte antes de sugerir alterações que afetem segurança.
 - `docs/PRIVACY.md`: baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes). Use ao propor logs, telemetria ou novas fontes de dados de usuário.
- - `docs/TESTING.md`: estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI). Consulte ao sugerir novos testes ou ajustar pipelines.
+- `docs/TESTING.md`: estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI). Consulte ao sugerir novos testes ou ajustar pipelines.
+ - `docs/OBSERVABILITY.md`: diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals). Use ao propor logging, métricas ou instrumentação de serviços.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,46 @@
+# Observabilidade — Car Fuel
+
+Este documento reúne diretrizes de observabilidade para o projeto Car Fuel (logs, métricas, tracing, health checks e alertas).
+
+## Logs (JSON estruturado)
+- Formato recomendado:
+  - `timestamp`
+  - `level` (info/warn/error)
+  - `message`
+  - `requestId` (para correlação com métricas/traces)
+  - `context` (ex.: endpoint, usuário, vehicleId — sem dados sensíveis em claro)
+- Evitar incluir PII (e-mail, placa completa, dados pessoais) diretamente nos logs; ver `docs/PRIVACY.md`.
+- Em dev/local, logs podem ser mais verbosos; em prod, priorizar informações úteis para diagnóstico.
+
+## Métricas
+- Métricas técnicas principais:
+  - Latência por endpoint (p50/p95/p99).
+  - Taxa de erro (4xx/5xx) por endpoint.
+  - Throughput (requisições/segundo).
+- Métricas de negócio (futuro):
+  - Número de abastecimentos registrados.
+  - Consumo médio por veículo/período.
+- Sempre que possível, incluir labels como `env`, `service`, `endpoint`.
+
+## Tracing (OpenTelemetry)
+- Cada requisição deve ter um `traceId` e, idealmente, `spanId` para operações internas.
+- `requestId` em logs deve ser correlacionável com `traceId`.
+- Futuramente, usar OpenTelemetry (OTel) para instrumentar serviços e enviar traces a um coletor.
+
+## Health checks
+- Endpoints de saúde sugeridos (futuro backend):
+  - `/health/live` — indica se o processo está vivo.
+  - `/health/ready` — indica se o serviço está pronto para receber tráfego (dependências principais OK).
+- Health checks devem ser leves e não carregar operações pesadas.
+
+## Alertas
+- Alertas devem ser baseados em métricas, por exemplo:
+  - Aumento significativo na taxa de erros 5xx.
+  - Latência acima dos SLOs definidos em `docs/NFR.md`.
+  - Falhas recorrentes em health checks.
+- Criticidade e canais de alerta podem ser definidos posteriormente, conforme o ambiente (ver `docs/ENVIRONMENTS.md`).
+
+## Web Vitals (frontend futuro)
+- Para uma eventual UI web, considerar métricas de experiência como LCP, FID e CLS.
+- Coletas devem respeitar `docs/PRIVACY.md` (telemetria sem dados pessoais identificáveis).
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/ENVIRONMENTS.md` — visão de ambientes (local/dev/prod), variáveis/segredos, CORS, flags, observabilidade por ambiente, limites, dados e promoção.
 - `docs/SECURITY.md` — diretrizes gerais de segurança (authN/authZ, transporte, CORS, rate limiting, segredos, supply chain, CI/CD, incidentes).
 - `docs/PRIVACY.md` — baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes).
- - `docs/TESTING.md` — estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI).
+- `docs/TESTING.md` — estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI).
+ - `docs/OBSERVABILITY.md` — diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #123
<!-- stack-section:end -->

Cria o documento  com diretrizes de observabilidade e integra com as demais docs, atendendo à Issue #14.

- Define práticas para logs JSON estruturados, métricas técnicas/negócio e tracing (OpenTelemetry)
- Descreve health checks (live/ready) e orientações gerais de alertas
- Menciona Web Vitals para um futuro frontend, alinhado com PRIVACY
- Atualiza  e  para incluir OBSERVABILITY no índice e no contexto de agentes

Closes #14
