### PR TITLE
docs(contributing): criar CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/SECURITY.md`: baseline de segurança (authZ/authN, transporte, CORS, rate limiting, segredos/cripto, supply chain, CI/CD, auditoria, incidentes). Consulte antes de sugerir alterações que afetem segurança.
 - `docs/PRIVACY.md`: baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes). Use ao propor logs, telemetria ou novas fontes de dados de usuário.
 - `docs/TESTING.md`: estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI). Consulte ao sugerir novos testes ou ajustar pipelines.
- - `docs/OBSERVABILITY.md`: diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals). Use ao propor logging, métricas ou instrumentação de serviços.
+- `docs/OBSERVABILITY.md`: diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals). Use ao propor logging, métricas ou instrumentação de serviços.
+ - `docs/CONTRIBUTING.md`: guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases). Útil para alinhar automações e fluxos propostos pelo agente.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contribuindo — Car Fuel
+
+Este documento explica como contribuir com o projeto Car Fuel. Ele complementa `docs/DIRETRIZES.md`, `docs/STACK-PR-GHSTACK.md`, `docs/PROJECTS.md` e demais guias.
+
+## Branches
+- Branch padrão única: `main`.
+- Crie branches de trabalho a partir de `main`, usando nomes descritivos, por exemplo:
+  - `feat/<resumo>`
+  - `fix/<resumo>`
+  - `docs/<resumo>`
+  - `chore/<resumo>`
+- Sempre associe a branch a uma Issue (e card no Project v2) quando possível.
+
+## Commits (Conventional Commits)
+- Use mensagens no padrão Conventional Commits:
+  - `feat: descrição curta`
+  - `fix: descrição curta`
+  - `docs: descrição curta`
+  - `ci: descrição curta`
+  - `chore: descrição curta`
+- Evite commits muito grandes; prefira mudanças pequenas e compreensíveis.
+
+## Stack PR (ghstack)
+- Para mudanças encadeadas, use ghstack conforme `docs/STACK-PR-GHSTACK.md`:
+  - Base: `main`.
+  - Publicar/atualizar pilha: `uvx --python 3.11 ghstack submit -B main` / `uvx --python 3.11 ghstack`.
+  - Landing automatizado opcional via workflow `ghstack-land`.
+
+## Checklist de contribuição
+- [ ] Existe uma Issue descrevendo o problema/feature (ou está claro no corpo da PR).
+- [ ] Branch criada a partir de `main` com nome descritivo.
+- [ ] Commits seguem Conventional Commits.
+- [ ] Testes relevantes foram adicionados/atualizados (ver `docs/TESTING.md`).
+- [ ] Documentação foi ajustada quando necessário (`docs/README.md`, guias específicos, etc.).
+- [ ] A PR referencia as Issues com `Closes #<id>` quando aplicável.
+
+## Code review
+- Repositório de único mantenedor:
+  - Pode não haver revisão por terceiros, mas recomenda‑se revisar a própria PR antes do merge.
+  - Sempre aguardar checks verdes antes de mesclar.
+- Com 2+ contribuidores:
+  - Exigir pelo menos 1 aprovação antes do merge.
+  - Usar o template de PR (`.github/pull_request_template.md`) para manter o checklist.
+
+## DoD (Definition of Done)
+Um item é considerado "Done" quando:
+- O código está implementado e passa nos testes relevantes.
+- A documentação afetada foi atualizada.
+- A Issue/Project foi atualizada (status, campos do Project v2, links para PR).
+- Não há TODOs críticos não tratados no código.
+
+## Releases
+- Releases são feitas via merges em `main`, frequentemente referenciadas em `docs/project/PHASE_PLAN.md`.
+- Para grupos maiores de mudanças, usar PRs de release dedicadas (ex.: "release: fase X").
+- Sempre que possível, usar `Closes #<id>` nas PRs relacionadas para garantir rastreabilidade entre código e Issues.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/SECURITY.md` — diretrizes gerais de segurança (authN/authZ, transporte, CORS, rate limiting, segredos, supply chain, CI/CD, incidentes).
 - `docs/PRIVACY.md` — baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes).
 - `docs/TESTING.md` — estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI).
- - `docs/OBSERVABILITY.md` — diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals).
+- `docs/OBSERVABILITY.md` — diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals).
+ - `docs/CONTRIBUTING.md` — guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #124
<!-- stack-section:end -->

Cria o documento  com o guia de contribuição e integra com o índice/AGENTS, atendendo à Issue #15.

- Descreve convenções de branches baseadas em  e nomes descritivos
- Reforça uso de Conventional Commits
- Explica quando/como usar Stack PR com ghstack (referenciando )
- Define checklist de contribuição, expectativas de code review e DoD
- Atualiza  e  para incluir o guia de contribuição

Closes #15
