### PR TITLE
docs(dev-setup): criar DEVELOPER_SETUP.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Este repositório usa ghstack como fluxo padrão para PRs empilhadas. Quando est
 - `docs/PRIVACY.md`: baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes). Use ao propor logs, telemetria ou novas fontes de dados de usuário.
 - `docs/TESTING.md`: estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI). Consulte ao sugerir novos testes ou ajustar pipelines.
 - `docs/OBSERVABILITY.md`: diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals). Use ao propor logging, métricas ou instrumentação de serviços.
- - `docs/CONTRIBUTING.md`: guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases). Útil para alinhar automações e fluxos propostos pelo agente.
+- `docs/CONTRIBUTING.md`: guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases). Útil para alinhar automações e fluxos propostos pelo agente.
+ - `docs/DEVELOPER_SETUP.md`: setup de desenvolvimento (pré‑requisitos, encoding, Gradle wrapper, variáveis de ambiente, troubleshooting). Consulte ao orientar ajustes de ambiente local ou PATH.
 
 ## ghstack (stacks de PR)
 1. Faça commits na `main` (branch única).

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -1,0 +1,45 @@
+# Setup de Desenvolvimento — Car Fuel
+
+Este guia ajuda a preparar o ambiente de desenvolvimento para o Car Fuel.
+
+## Pré‑requisitos
+- Git instalado e configurado.
+- Ferramentas de linha de comando:
+  - `gh` (GitHub CLI) autenticado (`gh auth status`).
+  - `uv` + `uvx` para rodar ferramentas Python (ghstack).
+  - PowerShell (Windows) para scripts em `scripts/*.ps1`.
+- IDE/editor com suporte a UTF‑8 (VS Code, IntelliJ, etc.).
+
+## Encoding e fim de linha
+- Usar **UTF‑8** como encoding padrão.
+- Em Windows, manter CRLF apenas onde o repositório já estiver configurado; evitar mudar fim de linha desnecessariamente.
+- Configure o editor para respeitar `.gitattributes` do projeto.
+
+## Gradle wrapper (backend futuro)
+- Quando houver backend Java/Kotlin, o wrapper será a forma padrão de build/teste:
+  - Linux/macOS: `./gradlew test`.
+  - Windows: `gradlew.bat test`.
+- Não é necessário instalar Gradle globalmente; use o wrapper versionado.
+
+## Variáveis de ambiente e `.env`
+- Para serviços locais (API/webapp futuros):
+  - Use arquivos `.env` **não versionados** ou variáveis de ambiente.
+  - Exemplos de variáveis (futuras): `CARFUEL_API_URL`, `CARFUEL_DB_URL`, `CARFUEL_LOG_LEVEL`.
+- Veja `docs/ENVIRONMENTS.md` para diretrizes por ambiente e `docs/PRIVACY.md` para cuidados com dados.
+
+## ghstack e uv
+- Instalar `uv` (ver instruções em `docs/STACK-PR-GHSTACK.md`).
+- Verificar:
+  - `uvx --python 3.11 ghstack --version`
+- Configurar `~/.ghstackrc` com token de repositório (PAT `repo`) conforme `docs/STACK-PR-GHSTACK.md`.
+
+## Troubleshooting
+- `uvx` não encontrado:
+  - Confirme instalação do `uv` e que `$HOME/.local/bin` (Linux/macOS) ou `%USERPROFILE%\.local\bin` (Windows) está no `PATH`.
+- Scripts PowerShell falhando:
+  - Verifique política de execução (`Set-ExecutionPolicy -Scope Process Bypass`) para a sessão atual.
+- Problemas de encoding/acentuação:
+  - Certifique‑se de que o arquivo está em UTF‑8 e que o editor não converte automaticamente para outro encoding.
+
+Para mais detalhes sobre fluxo de contribuição e testes, veja `docs/CONTRIBUTING.md` e `docs/TESTING.md`.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,8 @@ Se estiver usando um agente (Codex, etc.), veja também `AGENTS.md` para context
 - `docs/PRIVACY.md` — baseline de privacidade (classificação de dados, minimização, base legal, retenção, direitos, subprocessadores, telemetria, incidentes).
 - `docs/TESTING.md` — estratégia de testes (pirâmide, cobertura, ferramentas, contratos, dados de teste, flakiness, CI).
 - `docs/OBSERVABILITY.md` — diretrizes de observabilidade (logs JSON, métricas, tracing, health checks, alertas, web vitals).
- - `docs/CONTRIBUTING.md` — guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases).
+- `docs/CONTRIBUTING.md` — guia de contribuição (branches, Conventional Commits, Stack PR, checklist, code review, DoD, releases).
+ - `docs/DEVELOPER_SETUP.md` — setup de desenvolvimento (pré‑requisitos, encoding, Gradle wrapper, variáveis de ambiente, troubleshooting).
 - `docs/PROCESSO.md` — processo de trabalho (revisões, merges, uso de Issues/PRs, Projects v2).
 - `docs/PROJECTS.md` — guia do GitHub Projects v2 (colunas, campos, views e fluxo backlog→merge).
 - `docs/STACK-PR-GHSTACK.md` — guia de Stack PR com ghstack (pilhas baseadas em `main` + workflow `ghstack-land`).


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #125
<!-- stack-section:end -->

Cria o documento  com o setup de desenvolvimento e integra com o índice/AGENTS, atendendo à Issue #16.

- Documenta pré‑requisitos (Git, gh, uv/uvx, PowerShell, IDE com UTF‑8)
- Registra pontos de atenção com encoding e fim de linha
- Explica o papel do Gradle wrapper para backend futuro
- Orienta uso de  e variáveis de ambiente, alinhado a  e 
- Adiciona seção de troubleshooting para problemas comuns (uvx, scripts PowerShell, encoding)
- Atualiza  e  para incluir o setup de dev

Closes #16
