### PR TITLE
ci: ignorar branches gh/ ao inferir Issues

### DIFF
--- a/.github/workflows/stack-pr-body.yml
+++ b/.github/workflows/stack-pr-body.yml
@@ -90,13 +90,16 @@ jobs:
               const title = pr.title || '';
 
               // 1) Numbers in branch name (e.g., adr/129-backend-stack -> 129)
-              const branchMatches = ref.match(/\b(\d{1,5})\b/g) || [];
-              for (const raw of branchMatches){
-                const n = parseInt(raw, 10);
-                if (!Number.isNaN(n)) numbers.add(n);
+              //    Ignora branches internas do ghstack (gh/<user>/<id>/head)
+              if (!ref.startsWith('gh/')) {
+                const branchMatches = ref.match(/\b(\d{1,5})\b/g) || [];
+                for (const raw of branchMatches){
+                  const n = parseInt(raw, 10);
+                  if (!Number.isNaN(n)) numbers.add(n);
+                }
               }
 
-              // 2) Patterns in title (Closes #123, Fixes #123, Resolves #123)
+              // 2) Padrões explícitos no título (Closes #123, Fixes #123, Resolves #123)
               const patterns = [
                 /Closes\s*#(\d+)/ig,
                 /Fixes\s*#(\d+)/ig,
@@ -145,4 +148,3 @@ jobs:
             if (newBody !== (pr.body || '')){
               await github.rest.issues.update({ owner, repo, issue_number: prNumber, body: newBody });
             }
-


### PR DESCRIPTION
<!-- stack-section:begin -->
## Pilha
- Pai: main
- Próxima: (topo)
- Cadeia: #148
<!-- stack-section:end -->

Hotfix em .github/workflows/stack-pr-body.yml para evitar que branches internas do ghstack (gh/<user>/<id>/head) sejam usadas para inferir números de issue na seção 'Issues'. Agora apenas branches 'normais' (ex.: adr/129-backend-stack) são consideradas, além de padrões explícitos no título (Closes/Fixes/Resolves #id).

Isso corrige o problema observado no PR #147, onde o workflow inferiu indevidamente 'Closes #2' a partir do nome da branch interna gh/revton/2/head.

Closes #144.
